### PR TITLE
Use `Math` instead of `MathFloat` because MathFloat does not exists in androidM

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -39,6 +39,6 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:appcompat-v7:+'
+  compile 'com.android.support:appcompat-v7:21.+'
   compile project(':library')
 }

--- a/library/src/com/hannesdorfmann/swipeback/Scroller.java
+++ b/library/src/com/hannesdorfmann/swipeback/Scroller.java
@@ -19,7 +19,6 @@ package com.hannesdorfmann.swipeback;
 import android.content.Context;
 import android.hardware.SensorManager;
 import android.os.Build;
-import android.util.FloatMath;
 import android.view.ViewConfiguration;
 import android.view.animation.AnimationUtils;
 import android.view.animation.Interpolator;
@@ -371,7 +370,7 @@ class Scroller  {
 
             float dx = (float) (mFinalX - mStartX);
             float dy = (float) (mFinalY - mStartY);
-            float hyp = FloatMath.sqrt(dx * dx + dy * dy);
+            float hyp = (float) Math.sqrt(dx * dx + dy * dy);
 
             float ndx = dx / hyp;
             float ndy = dy / hyp;
@@ -388,7 +387,7 @@ class Scroller  {
         mMode = FLING_MODE;
         mFinished = false;
 
-        float velocity = FloatMath.sqrt(velocityX * velocityX + velocityY * velocityY);
+        float velocity = (float) Math.sqrt(velocityX * velocityX + velocityY * velocityY);
 
         mVelocity = velocity;
         final double l = Math.log(START_TENSION * velocity / ALPHA);


### PR DESCRIPTION
Causes the library to no longer work once you compile against 23.
